### PR TITLE
docs: release notes for 0.2.0

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,32 +7,33 @@ owner: Cloud Service Broker
 
 These are release notes for <%= vars.product_full %>.
 
-## <a id="0-1-0"></a> v0.1.0
+## <a id="0-2-0"></a> v0.2.0
 
-**Release Date:** February 22, 2022
+**Release Date:** April 15, 2022
 
 ### Breaking Changes
 
 This release has the following breaking change:
 
-* **Terraform v1.1.3**: <%= vars.product_short %> now uses Terraform v1.1.3.
+* **PostgreSQL instance properties can not be updated**
+* **Default PostgreSQL version 13:** This now matches the GCP default
+* **PostgreSQL bind users now deleted on unbind:** ownership of the objects they created is passed on to a "provision_user".
+As a result bindings created with previous versions cannot longer be managed by the broker. We recommend deleting the bindings before upgrading.
+To continue managing previously created service instances an update will need to be performed before doing any other operation.
 
 ### Features
 
 New features and changes in this release:
 
-* **Provision and update operations alert you if you attempt to override plan defined properties:**
-The attempt now returns an error. Previously these commands would accept the
-property change request, but override your change with the plan defined value.
-
-* **Validation of parameters:** When additional JSON parameters are supplied as part of
-`cf create-service`, `cf update-service`, `cf bind-service`, or `cf create-service-key` they are now
-validated against the list of supported parameters. The operation fails if a parameter is unknown.
+* **Feature flag for Beta services:** The feature flag tab allows operators to enable or disable beta services at a global level.
+* **Public IPs can be assigned to Postgresql databases on creation:** This can be enabled by setting the public_ip parameter which defaults to false
+* **PostgreSQL access control by IP:** List of IP addresses can now be specified to allow connections to a Postgresql database by setting the authorized_networks_cidrs parameter
 
 ### Resolved issues
 
 This release has the following fix:
 
-* **Parameters persist through multiple updates:**
-Parameters sent when updating a service are now stored and don't need to be sent again in subsequent
-updates.
+* **Beta services:** All service offerings and plans are highlighted to be at a Beta lifecycle state.
+* **Fixed typo defualt => default:** in the postgres service, now the size of storage volume should default to 10 GB
+
+

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -25,7 +25,10 @@ To continue managing previously created service instances an update will need to
 
 New features and changes in this release:
 
-* **Feature flag for Beta services:** The feature flag tab allows operators to enable or disable beta services at a global level.
+* **PostgreSQL plans are now configurable in the tile**
+* **Feature flag for Beta services:** The feature flag tab allows operators to enable or disable beta services at a global level. 
+All beta services are disabled by default. They can be enabled by ticking enable-beta-services.
+* **BROKERPAK_UPDATES_ENABLED feature always enabled:** HCL used when managing a service instance is always the latest taken from the brokerpak.
 * **Public IPs can be assigned to Postgresql databases on creation:** This can be enabled by setting the public_ip parameter which defaults to false
 * **PostgreSQL access control by IP:** List of IP addresses can now be specified to allow connections to a Postgresql database by setting the authorized_networks_cidrs parameter
 


### PR DESCRIPTION
This is still a beta product, but updating the release notes for the 0.2.0 release. 

This is pending OSL - expected 15/04