### PR TITLE
networking: explain that user is responsible for non-default config

### DIFF
--- a/installing-with-gcp.html.md.erb
+++ b/installing-with-gcp.html.md.erb
@@ -86,6 +86,13 @@ To configure GCP credentials:
 
 1. Click **Save**.
 
+<p class="note">
+  <strong>Note:</strong> <%= vars.product_short %> services are validated using the same GCP project and Region
+  for <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) and <%= vars.product_short %>. In other
+  configurations, make sure that <%= vars.app_runtime_abbr %> apps have network connectivity to the services
+  managed by <%= vars.product_short %>.
+</p>
+
 ### <a id="state-db"></a>Configure a State Database
 
 This section describes how to associate <%= vars.product_short %> with a MySQL database,


### PR DESCRIPTION
GCP has many ways to set up networking. The CSB is validated using one
configuration, with the expecation that it would work in all
configurations as long as the network connectivity is correct. The
intention of this text is to give users freedom to configure GCP as they
would like, while also giving them the resposibility of making sure that
it's right.

[#179942019](https://www.pivotaltracker.com/story/show/179942019)