### PR TITLE
docs: remove beta label for PostgreSQL

### DIFF
--- a/config/toc.md
+++ b/config/toc.md
@@ -2,7 +2,7 @@
 *   [Release Notes](/docs-csb-gcp/release-notes.html)
 *   [Installing and Configuring](/docs-csb-gcp/installing-with-gcp.html)
 *   [Service Plan Reference](/docs-csb-gcp/reference/index.html)
-    *   [Google PostgreSQL (Beta)](/docs-csb-gcp/reference/gcp-postgresql.html)
+    *   [Google PostgreSQL](/docs-csb-gcp/reference/gcp-postgresql.html)
     *   [Google MySQL (Beta)](/docs-csb-gcp/reference/gcp-mysql.html)
     *   [Google Storage Bucket (Beta)](/docs-csb-gcp/reference/gcp-storage.html)
     *   [Google Redis (Beta)](/docs-csb-gcp/reference/gcp-redis.html)

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: VMware Tanzu Cloud Service Broker for GCP (Beta)
+title: VMware Tanzu Cloud Service Broker for GCP
 owner: Cloud Service Broker
 ---
 
@@ -7,8 +7,8 @@ owner: Cloud Service Broker
 
 <p class="note warning">
 <strong>Warning: </strong>
-The <%= vars.product_full %> tile is currently in beta and is intended for evaluation and test purposes only.
-Do not use this product in a production environment.
+Some of the <%= vars.product_full %> tile services are currently in beta and are intended for evaluation and test purposes only.
+Do not use them in a production environment. Refer to the documentation for each service to determine whether it is in beta.
 </p>
 
 This documentation describes the <%= vars.product_full %>.

--- a/installing-with-gcp.html.md.erb
+++ b/installing-with-gcp.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Installing and Configuring Cloud Service Broker for GCP (Beta)
+title: Installing and Configuring Cloud Service Broker for GCP
 owner: Cloud Service Broker
 ---
 

--- a/reference/gcp-postgresql.html.md.erb
+++ b/reference/gcp-postgresql.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Google PostgreSQL Reference (Beta)
+title: Google PostgreSQL Reference
 owner: Cloud Service Broker
 ---
 

--- a/reference/index.html.md.erb
+++ b/reference/index.html.md.erb
@@ -10,7 +10,7 @@ parameters, and binding credentials for each service.
 
 See the topic below for the service you want to use:
 
-- [Google PostgreSQL (Beta)](gcp-postgresql.html)
+- [Google PostgreSQL](gcp-postgresql.html)
 - [Google MySQL (Beta)](gcp-mysql.html)
 - [Google Storage Bucket (Beta)](gcp-storage.html)
 - [Google Redis (Beta)](gcp-redis.html)

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Release Notes for Cloud Service Broker for GCP (Beta)
+title: Release Notes for Cloud Service Broker for GCP
 owner: Cloud Service Broker
 ---
 

--- a/uninstall.html.md.erb
+++ b/uninstall.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Uninstalling Cloud Service Broker for GCP (Beta)
+title: Uninstalling Cloud Service Broker for GCP
 owner: Cloud Service Broker
 ---
 


### PR DESCRIPTION
We intend to GA this product soon
- the beta label has been removed from the overall product
- the beta label has been removed from the PostgreSQL service

[#181342507](https://www.pivotaltracker.com/story/show/181342507)