### PR TITLE
fix: service images now display in apps manager

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -19,6 +19,12 @@ New features and changes in this release:
 * **Run-in header:** Description
 * **Run-in header:** Description
 
+### Resolved Issues
+
+This release has the following fixes:
+
+* **Apps Manager Service images:** The service image logo now displays in Apps Manager, or other GUI applications.
+
 ### Known issues
 
 There are no known issues for this release.


### PR DESCRIPTION
Hi Docs 👋 

Just a small fix in the upcoming release, previously the logos didn't display in Apps Manager, now they do!

[#183058257](https://www.pivotaltracker.com/story/show/183058257)

