### PR TITLE
GCP MySQL: enable storage auto-scaling controls

### DIFF
--- a/reference/gcp-mysql.html.md.erb
+++ b/reference/gcp-mysql.html.md.erb
@@ -92,6 +92,27 @@ provisioning a csb-google-mysql service:
     <td>provision and update</td>
   </tr>
   <tr>
+    <td><code>disk_autoresize</code></td>
+    <td>boolean</td>
+    <td>
+      Enables auto-resizing of the storage size.
+      If the value of the `disk_autoresize_limit` is other than 0, and you want to disable the functionality,
+      it will be necessary to set the property `disk_autoresize_limit` to zero and set `disk_autoresize` to false.
+    </td>
+    <td>true</td>
+    <td>provision and update</td>
+  </tr>
+  <tr>
+    <td><code>disk_autoresize_limit</code></td>
+    <td>number</td>
+    <td>
+      The maximum size in GB to which storage capacity can be automatically increased.
+      The default value is 0, which specifies that there is no limit.
+    </td>
+    <td>0</td>
+    <td>provision and update</td>
+  </tr>
+  <tr>
     <td><code>storage_gb</code></td>
     <td>string</td>
     <td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -32,6 +32,17 @@ New features and changes in this release:
   The `tier` property is now configurable at plan creation or instance operations for Google MySQL.
   The `tier` property determines the computation and memory capacity of a Google MySQL database instance.
 
+- **Storage auto-scaling controls exposed:**
+  New properties has been exposed to control the storage auto-scaling functionality.
+  You can change the behaviour through these properties:
+  
+  - `disk_autoresize`: Enables auto-resizing of the storage size.
+  Defaults to `true`.
+  If the value of the `disk_autoresize_limit` is other than 0, and you want to disable the functionality,
+  it will be necessary to set the property `disk_autoresize_limit` to zero and set `disk_autoresize` to false.
+  - `disk_autoresize_limit`: The maximum size in GB to which storage capacity can be automatically increased.
+  The default value is 0, which specifies that there is no limit.
+
 ### Resolved Issues
 
 This release has the following fixes:


### PR DESCRIPTION
[#183885951](https://www.pivotaltracker.com/story/show/183885951)

Which other branches should this be merged with (if any)?

None
