### PR TITLE
GCP MySQL: remove the maximum value validation for the storage

### DIFF
--- a/reference/gcp-mysql.html.md.erb
+++ b/reference/gcp-mysql.html.md.erb
@@ -125,7 +125,7 @@ provisioning a csb-google-mysql service:
     <td><code>storage_gb</code></td>
     <td>string</td>
     <td>
-      (Required unless defined in plan) Size of storage volume for service instance, 10&ndash;4096&nbsp;GB.
+      (Required unless defined in plan) Size of storage volume for service instance, 10GB to 65TB.
     </td>
     <td><code>10</code></td>
     <td>provision and update</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -48,6 +48,10 @@ New features and changes in this release:
   when creating a plan or creating and updating the instance.
   This property is required if it is not defined in the plan.
 
+- **Maximum storage capacity limit removed:**
+  The maximum storage capacity limit has been removed. From now on, you can select a storage capacity of up to 65 TB.
+  Capacity cannot be reduced later.
+
 ### Resolved Issues
 
 This release has the following fixes:


### PR DESCRIPTION
[#183888016](https://www.pivotaltracker.com/story/show/183888016)

Which other branches should this be merged with (if any)?

None
