### PR TITLE
GCP Storage && MySQL: Remove display_name from additional plans docs

### DIFF
--- a/reference/gcp-mysql.html.md.erb
+++ b/reference/gcp-mysql.html.md.erb
@@ -30,7 +30,6 @@ The following table lists parameters which can only be configured for additional
 | `name`            | The plan name                                                                    | _n/a_   | Yes      |
 | `id`              | A unique GUID                                                                    | _n/a_   | Yes      |
 | `description`     | Description of the new plan                                                      | _n/a_   | Yes      |
-| `display_name`    | Name to use when displaying plan in marketplace                                  | _n/a_   | No       |
 | `free`            | When false, Service Instances of this Service Plan have a cost                   | true    | No       |
 | `bindable`        | Specifies whether Service Instances of the Service Plan can bind to applications | true    | No       |
 | `plan_updateable` | Whether the Plan supports upgrade/downgrade/sidegrade to another version         | true    | No       |

--- a/reference/gcp-storage.html.md.erb
+++ b/reference/gcp-storage.html.md.erb
@@ -31,15 +31,14 @@ For how to configure plans, see
 
 The following table lists parameters which can only be configured for additional plans:
 
-| Parameter Name       | Values                         | Default   |
-|----------------------|--------------------------------|-----------|
-| `name`*              | The plan name                  | _n/a_     |
-| `id`*                | A unique GUID                  | _n/a_     |
-| `description`*       | Description of the new plan    | _n/a_     |
-| `display_name`       | Name to use when displaying plan in marketplace    | _n/a_     |
-| `free`               | When false, Service Instances of this Service Plan have a cost    | true     |
-| `bindable`           | Specifies whether Service Instances of the Service Plan can bind to applications    | true     |
-| `plan_updateable`    | Whether the Plan supports upgrade/downgrade/sidegrade to another version    | true     |
+| Parameter Name    | Values                                                                           | Default |
+|-------------------|----------------------------------------------------------------------------------|---------|
+| `name`*           | The plan name                                                                    | _n/a_   |
+| `id`*             | A unique GUID                                                                    | _n/a_   |
+| `description`*    | Description of the new plan                                                      | _n/a_   |
+| `free`            | When false, Service Instances of this Service Plan have a cost                   | true    |
+| `bindable`        | Specifies whether Service Instances of the Service Plan can bind to applications | true    |
+| `plan_updateable` | Whether the Plan supports upgrade/downgrade/sidegrade to another version         | true    |
 
 <sup>*</sup> Required
 


### PR DESCRIPTION
[#184548051](https://www.pivotaltracker.com/story/show/184548051)

Which other branches should this be merged with (if any)?

None
