### PR TITLE
consistency of default values

### DIFF
--- a/reference/gcp-mysql.html.md.erb
+++ b/reference/gcp-mysql.html.md.erb
@@ -78,7 +78,7 @@ provisioning a csb-google-mysql service:
       For more information, see the
       <a href="https://cloud.google.com/sql/docs/mysql/instance-settings">Google Cloud documentation</a>.
     </td>
-    <td><code>""</code></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -119,7 +119,7 @@ provisioning a csb-google-mysql service:
       version that the provider supports. Note that enforcing secure connections is only supported with MySQL v5.7
       and later. If you are using MySQL v5.6, you must also set the <code>allow_insecure_connections</code> property.
     </td>
-    <td><code>""</code></td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>
@@ -214,7 +214,7 @@ provisioning a csb-google-mysql service:
     <td>
       The name of the GCP region in which to store the backup.
     </td>
-    <td></td>
+    <td><code>null</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/gcp-postgresql.html.md.erb
+++ b/reference/gcp-postgresql.html.md.erb
@@ -89,7 +89,7 @@ whether a parameter is supported for both provision and update, or for provision
     <code>db-custom-8-8192</code>.  For more information about machine types, see the
     <a href="https://cloud.google.com/sql/docs/postgres/create-instance#machine-types">Google Cloud documentation</a>.
     </td>
-    <td> _n/a_ </td>
+    <td>None</td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/gcp-redis.html.md.erb
+++ b/reference/gcp-redis.html.md.erb
@@ -101,7 +101,7 @@ provisioning a csb-google-redis service:
     <td>
       Permanent identifier for your instance.
     </td>
-    <td><code>pcf-sb-INSTANCE_COUNT-TIMESTAMP</code></td>
+    <td><code>csb-INSTANCE-ID</code></td>
     <td>provision and update</td>
   </tr>
   <tr>

--- a/reference/gcp-spanner.html.md.erb
+++ b/reference/gcp-spanner.html.md.erb
@@ -112,7 +112,7 @@ provisioning a csb-google-spanner service:
   </tr>
   <tr>
     <td><code>ddl</code></td>
-    <td>string</td>
+    <td>array</td>
     <td>
       An optional list of DDL statements to run inside the newly created database.
     </td>


### PR DESCRIPTION
- if enclosed in &lt;code&gt;, the value should exactly match the brokerpak spec
- when no default exists, `None` should be used rather than N/A
- where the default is badly formatted (csbINSTANCE-ID for instance) the docs should show the value that matches the brokerpak spec, rather than what we thing the brokerpak spec should have been

[#184710879](https://www.pivotaltracker.com/story/show/184710879)

Which other branches should this be merged with (if any)?
- 1.2
- 1.1
- 1.0
