### PR TITLE
fix: improve stack selection logic

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -29,7 +29,7 @@ This release has the following fixes:
 
 <%= partial vars.path_to_partials + '/csb/timeout-resolved' %>
 
-**Improve stack selection to try with "cflinuxfs3" before using the default value:**
+- **Improve stack selection to try with "cflinuxfs3" before using the default value:**
 
   Previously, it was possible in some scenarios that the default value was a Windows stack causing
   tile installation to fail.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -29,6 +29,11 @@ This release has the following fixes:
 
 <%= partial vars.path_to_partials + '/csb/timeout-resolved' %>
 
+**Improve stack selection to try with "cflinuxfs3" before using the default value:**
+
+  Previously, it was possible in some scenarios that the default value was a Windows stack causing
+  tile installation to fail.
+
 ### Known issues
 
 There are no known issues in this release.


### PR DESCRIPTION
[#185675276]

When there are multiple build packs installed and non of them is a cflinuxfs4 , when creating the droplet for the tile with the default stack, CF will just take the first matching one.

But if both Windows and Linux have installed the binary_buildpack, it can happen that it matches a Windows buildpack. The implemented solution is to also check for cflinuxfs3 in the get_stack() function

Which other branches should this be merged with (if any)? none
