### PR TITLE
doc: known issue selecting stack during install

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -25,7 +25,14 @@ This release fixes the following issues:
 
 ### Known issues
 
-There are no known issues in this release.
+This release has the following issues:
+
+#### General
+
+- **Failure to select the right stack during install:**
+
+  When there are multiple build packs installed and non of them is a cflinuxfs4, it can happen that 
+  it matches a Windows buildpack if both Windows and Linux have installed the binary_buildpack.
 
 ## <a id="1-2-1"></a> v1.2.1
 


### PR DESCRIPTION
[#185675276]

When there are multiple build packs installed and non of them is a cflinuxfs4 , when creating the droplet for the tile with the default stack, CF will just take the first matching one.

But if both Windows and Linux have installed the binary_buildpack, it can happen that it matches a Windows buildpack.

Which other branches should this be merged with (if any)? none
