### PR TITLE
MySQL does not allow insecure connection by default

### DIFF
--- a/reference/gcp-mysql.html.md.erb
+++ b/reference/gcp-mysql.html.md.erb
@@ -287,6 +287,10 @@ provisioning a csb-google-mysql service:
       Specifies whether insecure connections are allowed for this service instance.
       Note that enforcing secure connections is not supported by MySQL v5.6.
       If you are using MySQL v5.6, you must set this property to <code>true</code>.
+      Despite `allow_insecure_connections` being `false`, there might be a misconception based
+      on the settings visible in the Google Cloud Console.
+      These settings reflect `server-level` configurations, whereas the CSB enforces security at the user level,
+      ensuring that all bindings (user credentials) created by CSB mandate SSL connections.
     </td>
     <td><code>false</code></td>
     <td>provision</td>


### PR DESCRIPTION
Add clarification note to avoid misconception

[#187890616](https://www.pivotaltracker.com/story/show/187890616)


Which other branches should this be merged with (if any)?

**1.5, 1.4, 1.3, 1.2**

